### PR TITLE
Use indexOf instead of includes for IE compatibility.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,7 +7,7 @@ import '../css/App.css';
 
 const stats = require('../stats.json');
 const years = Object.keys(stats).map(k => k.substring(0, 4)).reduce((p, c) => {
-  if (!p.includes(c)) p.push(c);
+  if (p.indexOf(c) === -1) p.push(c);
   return p;
 }, []);
 

--- a/src/components/y-axis.js
+++ b/src/components/y-axis.js
@@ -9,6 +9,10 @@ class Yaxis extends Component {
     const {y1, y2, label} = this.props;
     return (y2 + y1)/2 + label.length*4; // TODO Fix this hack,
   }
+  getTickXValue(tickX, tickValue) {
+    // Major hack alert below :)
+    return tickX - 15 - tickValue.toString().length*6;
+  }
   render() {
     const {ticks, x, y1, y2, label} = this.props;
     const elements = [
@@ -18,7 +22,7 @@ class Yaxis extends Component {
     ticks.forEach(
       tick => {
         elements.push(<line fill="none" x1={x-tickLength} y1={tick.Y} x2={x} y2={tick.Y} key={`y-axis-tick-${tick.Value}`} />);
-        elements.push(<text className="axis-tick-label" stroke="none" x={x-30} y={tick.Y+5} key={`y-axis-tick-label-${tick.Value}`}>{tick.Value.toString().padStart(3, '\xa0')}</text>);
+        elements.push(<text className="axis-tick-label" stroke="none" x={this.getTickXValue(x, tick.Value)} y={tick.Y+5} key={`y-axis-tick-label-${tick.Value}`}>{tick.Value}</text>);
       }
     );
     return (<g className="axis-root">{elements}</g>);


### PR DESCRIPTION
IE has no implementation of `Array.prototype.includes` and `String.prototype.padStart`

cc @eoin @mckenna